### PR TITLE
Use volume for tempo data, prevent port conflicts, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,13 @@
 
 ## What is Gander?
 
-Gander is a preconfigured Open Telemetry stack relying on Prometheus, Grafana, and Grafana Tempo.
+[Gander](https://www.tag1consulting.com/gander) is a preconfigured Open Telemetry stack relying on Prometheus, Grafana, and Grafana Tempo.
 
 `ddev get tag1consulting/ddev-gander`, run Drupal core's OpenTelemetry phpunit tests, and immediately see performance metrics and traces in a Grafana dashboard. Or add PerformanceTestBase coverage to an existing project with a few lines of code if you already have phpunit functional test coverage of your project.
 
 For more information on the phpunit side of things, see [the Drupal core change record](https://www.drupal.org/node/3366904).
 
+For more information [check the documentation](https://docs.google.com/document/d/1lIps5uDwF1sN6662K-J94eRpHBySXV6giMMXODnWezM/edit).
 
 ## Prerequisites:
 * [Install ddev](https://ddev.readthedocs.io/en/latest/users/install/ddev-installation/) if you haven't already.
@@ -24,10 +25,12 @@ For most use cases, this chrome image should work out of the box:
 ```ddev get ddev/ddev-selenium-standalone-chrome```
 
 ## Getting started
-Add Gander and run Drupal's performance tests via a git clone of Drupal core:
+Add Gander and run Drupal's performance tests via a git clone of Drupal core (assuming [composer is 
+used](https://www.drupal.org/docs/develop/using-composer/manage-dependencies)):
 * `ddev get tag1consulting/ddev-gander`
 * `ddev restart`
 * `ddev ssh`
-* To run a single test three times in order to check the Gander installation, ensure you're in the document root first: `for run in 1..3; do vendor/bin/phpunit -c core/phpunit.xml profiles/demo_umami/tests/src/FunctionalJavascript/OpenTelemetryNodePagePerformanceTest.php --filter hot; done;`
-* To run all OpenTelemetry tests: `vendor/bin/phpunit -c core/phpunit.xml --group OpenTelemetry`
-* Check the Grafana dashboard via: http://localhost:3000/
+* `cd web/`
+* To run a single test three times in order to check the Gander installation, ensure you're in the document root first: `for run in 1..3; do ../vendor/bin/phpunit -c core profiles/demo_umami/tests/src/FunctionalJavascript/OpenTelemetryNodePagePerformanceTest.php --filter hot; done;`
+* To run all OpenTelemetry tests: `../vendor/bin/phpunit -c core --group OpenTelemetry`
+* Check the Grafana dashboard via: _http://\<projectname\>.ddev.site:3000/_

--- a/docker-compose.gander.yaml
+++ b/docker-compose.gander.yaml
@@ -32,7 +32,7 @@ services:
     volumes:
       - ./gander-shared/prometheus.yaml:/etc/prometheus.yaml
     ports:
-      - "9090:9090"
+      - "9090"
 
   grafana:
     image: grafana/grafana:latest
@@ -46,7 +46,7 @@ services:
       - GF_AUTH_DISABLE_LOGIN_FORM=true
       - GF_FEATURE_TOGGLES_ENABLE=traceqlEditor
     ports:
-      - "3000:3000"
+      - "3000"
 
 volumes:
   tempo-data:

--- a/docker-compose.gander.yaml
+++ b/docker-compose.gander.yaml
@@ -15,7 +15,7 @@ services:
     command: [ "-config.file=/etc/tempo.yaml" ]
     volumes:
       - ./gander-shared/tempo.yaml:/etc/tempo.yaml
-      - ./tempo-data:/tmp/tempo
+      - tempo-data:/tmp/tempo
     ports:
       - "14268"  # jaeger ingest
       - "3200"   # tempo
@@ -47,3 +47,6 @@ services:
       - GF_FEATURE_TOGGLES_ENABLE=traceqlEditor
     ports:
       - "3000:3000"
+
+volumes:
+  tempo-data:


### PR DESCRIPTION
Fixes the following minor issues:

- `tempo-data` folder not being writable. It uses docker volume instead. 
- Lets DDEV handle exposed ports for Prometheus and Tempo to prevent conflicts if multiple projects use the same ports. Services will now be available _https://\<projectname\>.ddev.site:3000/_ and _https://\<projectname\>.ddev.site:9090/_
- Updates README with the above changes, adds a link to Gander cornerstone page and documentation Google document. 

We have to remember to update the docs url when we move them to the permanent home. 