### PR TITLE
Tempo can't mkdir

### DIFF
--- a/docker-compose.gander.yaml
+++ b/docker-compose.gander.yaml
@@ -18,7 +18,7 @@ services:
       - "10001:10001"
       - "/var/tempo"
     volumes:
-      - ./tempo-data:/var/tempo
+      - tempo-data:/var/tempo
 
   # To eventually offload to Tempo...
   tempo:
@@ -27,7 +27,7 @@ services:
     command: [ "-config.file=/etc/tempo.yaml" ]
     volumes:
       - ./gander-shared/tempo.yaml:/etc/tempo.yaml
-      - ./tempo-data:/var/tempo
+      - tempo-data:/var/tempo
     ports:
       - "14268"  # jaeger ingest
       - "3200"   # tempo

--- a/docker-compose.gander.yaml
+++ b/docker-compose.gander.yaml
@@ -10,20 +10,32 @@ services:
     volumes:
       - ./otel-collector.yaml:/etc/otel-collector.yaml
 
+  init:
+    image: &tempoImage grafana/tempo:latest
+    user: root
+    entrypoint:
+      - "chown"
+      - "10001:10001"
+      - "/var/tempo"
+    volumes:
+      - ./tempo-data:/var/tempo
+
   # To eventually offload to Tempo...
   tempo:
-    image: grafana/tempo:latest
+    image: *tempoImage
     container_name: ddev-${DDEV_SITENAME}-tempo
     command: [ "-config.file=/etc/tempo.yaml" ]
     volumes:
       - ./gander-shared/tempo.yaml:/etc/tempo.yaml
-      - tempo-data:/tmp/tempo
+      - ./tempo-data:/var/tempo
     ports:
       - "14268"  # jaeger ingest
       - "3200"   # tempo
       - "4317"  # otlp grpc
       - "4318"  # otlp http
       - "9411"   # zipkin
+    depends_on:
+      - init
 
   prometheus:
     image: prom/prometheus:latest

--- a/gander-shared/tempo.yaml
+++ b/gander-shared/tempo.yaml
@@ -34,7 +34,7 @@ metrics_generator:
       dimensions:
         - service.version
   storage:
-    path: /tmp/tempo/generator/wal
+    path: /var/tempo/generator/wal
     remote_write:
       - url: http://prometheus:9090/api/v1/write
         send_exemplars: true
@@ -44,9 +44,9 @@ storage:
   trace:
     backend: local                     # backend configuration to use
     wal:
-      path: /tmp/tempo/wal             # where to store the the wal locally
+      path: /var/tempo/wal # where to store the the wal locally
     local:
-      path: /tmp/tempo/blocks
+      path: /var/tempo/blocks
 
 overrides:
   metrics_generator_processors: [service-graphs, span-metrics] # enables metrics generator


### PR DESCRIPTION
The tempo container wasn' starting for me with the following error:

```
level=error ts=2024-05-24T13:11:11.8167803Z caller=main.go:121 msg="error running Tempo" err="failed to init module services: error initialising module: store: failed to create store: mkdir /tmp/tempo/blocks: permission denied"
```

This issue https://github.com/grafana/tempo/issues/3601 looks like the same and they fixed the examples so the tempo-data volume has the right user and permissions in https://github.com/grafana/tempo/pull/3603, this is the example that has worked for me: https://github.com/zalegrala/tempo/blob/cdd03257405f292f672882a5d7b5434d7d3c2fe7/example/docker-compose/local/docker-compose.yaml