### PR TITLE
Fix tempo + otel-collector not binding to 0.0.0.0 + update otel collector

### DIFF
--- a/docker-compose.gander.yaml
+++ b/docker-compose.gander.yaml
@@ -15,7 +15,7 @@ services:
 
   # And put them in an OTEL collector pipeline...
   otel-collector:
-    image: otel/opentelemetry-collector:0.61.0
+    image: otel/opentelemetry-collector:0.132.2
     container_name: ddev-${DDEV_SITENAME}-otel-collector
     command: [ "--config=/etc/otel-collector.yaml" ]
     labels:

--- a/gander-config/otel-collector.yaml
+++ b/gander-config/otel-collector.yaml
@@ -2,8 +2,12 @@
 receivers:
   otlp:
     protocols:
+      # Updates to image made otel-collector bind to localhost by default,
+      # This allows external access
       grpc:
+        endpoint: 0.0.0.0:4317
       http:
+        endpoint: 0.0.0.0:4318
 exporters:
   otlp:
     endpoint: tempo:4317

--- a/gander-config/tempo.yaml
+++ b/gander-config/tempo.yaml
@@ -13,8 +13,12 @@ distributor:
     zipkin:
     otlp:
       protocols:
+        # Updates to image made tempo bind to localhost by default,
+        # This allows external access
         http:
+          endpoint: "0.0.0.0:4318"
         grpc:
+          endpoint: "0.0.0.0:4317"
     opencensus:
 
 ingester:


### PR DESCRIPTION
## Issue Description
Changes in newer tempo versions caused it to bind to localhost instead of 0.0.0.0. When running in docker/ddev, this means other containers like otel-collector cannot reach it. Tempo version is unpinned here, so this has is currently broken.

I also updated the otel-collector image tag, which has made a similar change upstream. I have also updated otel-collector config to bind to 0.0.0.0.

## Verifying issue
If setup recommended project with current addon version: `ddev add-on get tag1consulting/ddev-gander`, traces after test run will not show up in grafana. Errors can be found in otel-collector container logs indicating failing to connect to tempo.

## Verifying Fix
I setup another copy of recommended project and installed this addon with fixes in PR using `ddev add-on get <local-path-to-clone-of-fixed-branch>`, and can confirm traces are seen in grafana as expected.
