### PR TITLE
make init service stay up instead of exiting, fixes ddev/ddev#8389

### DIFF
--- a/docker-compose.gander.yaml
+++ b/docker-compose.gander.yaml
@@ -7,9 +7,9 @@ services:
     image: &tempoImage grafana/tempo:2.9.0
     user: root
     entrypoint:
-      - "chown"
-      - "10001:10001"
-      - "/var/tempo"
+      - "sh"
+      - "-c"
+      - "chown 10001:10001 /var/tempo && tail -f /dev/null"
     volumes:
       - tempo-data:/var/tempo
 


### PR DESCRIPTION
See ddev/ddev#8389

In recent DDEV releases a service in docker-compose.*.yaml is required to stay up, not immediately exit. 

But the `init` service here immediately exits.

Test with 
```
ddev add-on get https://github.com/rfay/ddev-gander/tarball/20260506_rfay_init_should_stay_up
```
